### PR TITLE
fix: Remove `position` from driver standings primary key

### DIFF
--- a/tap_f1/streams.py
+++ b/tap_f1/streams.py
@@ -441,7 +441,7 @@ class DriverStandingsStream(F1Stream):
 
     parent_stream_type = RacesStream
     name = "driver_standings"
-    primary_keys = ("season", "round", "driverId", "position")
+    primary_keys = ("season", "round", "driverId")
     path = "/{season}/{round}/driverStandings.json"
     records_jsonpath = "MRData.StandingsTable.StandingsLists[*].DriverStandings[*]"
 

--- a/tap_f1/streams.py
+++ b/tap_f1/streams.py
@@ -492,7 +492,7 @@ class ConstructorStandingsStream(F1Stream):
 
     parent_stream_type = RacesStream
     name = "constructor_standings"
-    primary_keys = ("season", "round", "constructorId", "position")
+    primary_keys = ("season", "round", "constructorId")
     path = "/{season}/{round}/constructorStandings.json"
     records_jsonpath = "MRData.StandingsTable.StandingsLists[*].ConstructorStandings[*]"
 


### PR DESCRIPTION
Turns out `position` can be `null` if a driver DNFs on the first race of a season (as was the case this weekend):

- https://api.jolpi.ca/ergast/f1/2025/1/driverStandings.json
- https://api.jolpi.ca/ergast/f1/2023/1/driverStandings.json (similar example from Bahrain 2023)

`position` is redundant in driver standings primary key anyway - `season`, `round` and `driverId` are already enough to determine uniqueness.