### PR TITLE
chore: automate copyright notices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,15 @@ repos:
   - id: check-dependabot
   - id: check-github-workflows
 
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.6
+  hooks:
+  - id: insert-license
+    files: \.py$
+    args:
+    - --license-filepath=license_header.txt
+    - --use-current-year
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.16.1
   hooks:

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,1 @@
+Copyright (c) 2026 Reuben Frankel.

--- a/tap_f1/__init__.py
+++ b/tap_f1/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """Tap for F1."""

--- a/tap_f1/__main__.py
+++ b/tap_f1/__main__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """F1 entry point."""
 
 from __future__ import annotations

--- a/tap_f1/client.py
+++ b/tap_f1/client.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """REST client handling, including F1Stream base class."""
 
 from datetime import date, timedelta

--- a/tap_f1/pagination.py
+++ b/tap_f1/pagination.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """Pagination classes for tap-f1."""
 
 from singer_sdk.pagination import BaseOffsetPaginator

--- a/tap_f1/streams.py
+++ b/tap_f1/streams.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """Stream type classes for tap-f1."""
 
 from datetime import date

--- a/tap_f1/tap.py
+++ b/tap_f1/tap.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """F1 tap class."""
 
 from datetime import date, datetime, timezone

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """Test suite for tap-f1."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Reuben Frankel.
+
 """Tests standard tap features using the built-in SDK tests library."""
 
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
`tap-f1` has no copyright notice on its Python files. Each file needs one, and the year needs a manual bump. That is easy to forget and does not scale.

This change adds the notice automatically with the Lucas-C `insert-license` hook. The hook inserts the notice into every Python file and keeps the year current with `--use-current-year`. It runs on pre-commit.ci, so the autofix stamps any file that lacks the notice and a contributor never edits the header by hand.

The notice becomes a comment above the module docstring in every `.py` file, including the tests:

```python
# Copyright (c) 2026 Reuben Frankel.

"""Stream type classes for tap-f1."""
```

## Notes

- The hook writes a comment header above the module docstring, because `insert-license` inserts comment blocks.
- `--use-current-year` converts a single year to a range when the year changes, for example `2026-2027`. A range still satisfies the ruff `CPY001` rule.
- The `files` pattern limits the hook to `.py` files, because it applies to all text files by default. The `--comment-style` option is omitted because `#` is the default.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
