### PR TITLE
ci: run tests only on relevant file changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,19 @@ name: Test tap-f1
 on:
   push:
     branches: [main]
-    paths-ignore: [README.md]
+    paths:
+    - .github/workflows/test.yml
+    - tap_f1/**
+    - tests/**
+    - pyproject.toml
+    - uv.lock
   pull_request:
-    paths-ignore: [README.md]
+    paths:
+    - .github/workflows/test.yml
+    - tap_f1/**
+    - tests/**
+    - pyproject.toml
+    - uv.lock
   schedule:
   - cron: 0 9 * * *
   workflow_dispatch:


### PR DESCRIPTION
The test workflow runs pytest on every push and pull request, and pytest calls the upstream F1 API. So a change that cannot affect the tests, such as a pre-commit config edit, still hits the upstream API.

This change limits the `push` and `pull_request` triggers to the paths that affect the tests: `tap_f1/**`, `tests/**`, `pyproject.toml`, `uv.lock`, and the workflow file itself. The daily schedule and the manual dispatch stay unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
