### PR TITLE
chore: modernize the ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,9 +35,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.16.1
   hooks:
-  - id: ruff
-    args: [--fix, --exit-non-zero-on-fix, --show-fixes]
-    exclude: tests/
+  - id: ruff-check
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
The ruff hook uses the legacy `ruff` id and excludes `tests/`, so ruff — including the `CPY001` copyright rule — does not cover the test files.

This change switches to the modern `ruff-check` id and drops the `tests/` exclusion, so ruff covers every Python file, the tests included. It also drops the `--fix` args to match the SDK default. The repository is already clean, so nothing regresses.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
