### PR TITLE
fix: slow Python 3.14 test run

### DIFF
--- a/tap_f1/client.py
+++ b/tap_f1/client.py
@@ -22,18 +22,23 @@ class F1Stream(RESTStream):
     @override
     @cached_property
     def requests_session(self):
-        session = CachedSession(
+        return CachedSession(
             self.tap_name,
             use_cache_dir=True,
             expire_after=timedelta(days=1),
         )
-        # Pin Accept-Encoding so the Vary-based cache key stays stable across Python
-        # versions. Python 3.14 bundles zstd in the standard library, so urllib3
-        # advertises "gzip,deflate,zstd" instead of "gzip,deflate". Because the API
-        # sends "Vary: Accept-Encoding", that mismatch makes 3.14 miss the shared
-        # cache written by 3.10-3.13 and refetch every response from the upstream API.
-        session.headers["Accept-Encoding"] = "gzip, deflate"
-        return session
+
+    @property
+    @override
+    def http_headers(self) -> dict:
+        headers = super().http_headers
+        # Pin Accept-Encoding so the Vary-based requests-cache key stays stable across
+        # Python versions. Python 3.14 bundles zstd in the standard library, so urllib3
+        # otherwise advertises "gzip,deflate,zstd" instead of "gzip,deflate"; with the
+        # API's "Vary: Accept-Encoding", that makes 3.14 miss the shared cache written
+        # by 3.10-3.13 and refetch every response from the upstream API.
+        headers["Accept-Encoding"] = "gzip, deflate"
+        return headers
 
     @override
     def get_new_paginator(self):

--- a/tap_f1/client.py
+++ b/tap_f1/client.py
@@ -22,11 +22,18 @@ class F1Stream(RESTStream):
     @override
     @cached_property
     def requests_session(self):
-        return CachedSession(
+        session = CachedSession(
             self.tap_name,
             use_cache_dir=True,
             expire_after=timedelta(days=1),
         )
+        # Pin Accept-Encoding so the Vary-based cache key stays stable across Python
+        # versions. Python 3.14 bundles zstd in the standard library, so urllib3
+        # advertises "gzip,deflate,zstd" instead of "gzip,deflate". Because the API
+        # sends "Vary: Accept-Encoding", that mismatch makes 3.14 miss the shared
+        # cache written by 3.10-3.13 and refetch every response from the upstream API.
+        session.headers["Accept-Encoding"] = "gzip, deflate"
+        return session
 
     @override
     def get_new_paginator(self):


### PR DESCRIPTION
The test workflow's Python 3.14 job takes about 8 minutes, while 3.10-3.13 finish in seconds. On 3.14 the tests refetch every response from the upstream F1 API instead of reading the shared `requests-cache`, so each run also hammers that API.

Python 3.14 bundles zstd in the standard library, so `urllib3` advertises `Accept-Encoding: gzip,deflate,zstd` instead of the `gzip,deflate` that 3.10-3.13 send. The API responds with `Vary: Accept-Encoding`, and `requests-cache` keys cached entries by the `Vary` headers. So 3.14's requests do not match the entries that 3.10-3.13 wrote to the shared cache, every request misses, and the tap goes to the network.

This change pins `Accept-Encoding` to `gzip, deflate` via the stream `http_headers` property, so every Python version sends the same header, matches the same `Vary` variant, and shares one cache. The Python 3.14 job then reads from the cache like the others.

A capped diagnostic across the matrix confirmed the fix: with the pin, Python 3.14 goes from 0 cache hits to reading every response from the cache.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
