### PR TITLE
chore: upgrade url-normalize to remove idna deprecation warnings

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1060,14 +1060,14 @@ wheels = [
 
 [[package]]
 name = "url-normalize"
-version = "2.2.1"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/31/febb777441e5fcdaacb4522316bf2a527c44551430a4873b052d545e3279/url_normalize-2.2.1.tar.gz", hash = "sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37", size = 18846, upload-time = "2025-04-26T20:37:58.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/cd/846d87d6d49d963b04ef4429b73d71d3c17468059956bab360866a9b0aec/url_normalize-3.0.0.tar.gz", hash = "sha256:0552cbf2831a32a28994a13d29bca58a60e10ff6c0380e343ec6d1c2a0d232d8", size = 21777, upload-time = "2026-04-25T00:31:59.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/d9/5ec15501b675f7bc07c5d16aa70d8d778b12375686b6efd47656efdc67cd/url_normalize-2.2.1-py3-none-any.whl", hash = "sha256:3deb687587dc91f7b25c9ae5162ffc0f057ae85d22b1e15cf5698311247f567b", size = 14728, upload-time = "2025-04-26T20:37:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/13/8a/f72344eab18674fd7b174f35abbce41ed88fea72927f111726732d0ca779/url_normalize-3.0.0-py3-none-any.whl", hash = "sha256:95234bd359f86831c1fd87c248877f2a6887db2f3b5087120083f2fffcba4889", size = 16854, upload-time = "2026-04-25T00:31:58.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The test suite emits about 4,100 `DeprecationWarning`s from `url-normalize`, which calls `idna.encode(..., transitional=True)` — an argument that `idna` has deprecated. They clutter the pytest output on every run.

`url-normalize` 3.0.0 drops the `transitional=True` argument, so the warnings go away. The normalized URL output is unchanged, so the `requests-cache` keys and the shared cache are unaffected — no re-fetching.

This change upgrades `url-normalize` from `2.2.1` to `3.0.0` in `uv.lock`. `requests-cache` allows it (`url-normalize>=2.0`), and 3.0.0 supports Python `>=3.10`, matching the project.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
