### PR TITLE
chore: remove the OffsetPaginator deprecation warning

### DIFF
--- a/tap_f1/pagination.py
+++ b/tap_f1/pagination.py
@@ -2,11 +2,11 @@
 
 """Pagination classes for tap-f1."""
 
-from singer_sdk.pagination import BaseOffsetPaginator
+from singer_sdk.pagination import OffsetPaginator
 from typing_extensions import override
 
 
-class F1Paginator(BaseOffsetPaginator):
+class F1Paginator(OffsetPaginator):
     """Base API paginator."""
 
     @override


### PR DESCRIPTION
Anyone who runs or imports the tap sees a `SingerSDKPendingDeprecationWarning` from the paginator. The warning reads `Use OffsetPaginator instead`. It has appeared since the singer-sdk bump to `0.54.2` in #205 on 2026-05-19.

The Singer SDK deprecated `BaseOffsetPaginator` in favor of `OffsetPaginator` in the `0.54` series. `OffsetPaginator` has an identical constructor signature, and `BaseOffsetPaginator` is now a thin deprecated alias of it.

This change updates `F1Paginator` to inherit from `OffsetPaginator`. The rename removes the warning. No behavior changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
